### PR TITLE
Fix: Extend Strapi Handler Formatter

### DIFF
--- a/app/helpers/deployment-helpers.ts
+++ b/app/helpers/deployment-helpers.ts
@@ -30,7 +30,7 @@ const MAX_DOMAIN_LENGTH = 63;
 const BRANCH_HASH_LENGTH = 8;
 
 export function getBranchHandle(branchName: string) {
-  const handle = branchName.replace(/[\/_,]/g, "-");
+  const handle = branchName.replace(/[^a-zA-Z0-9]/g, "-");
   const hash = crypto
     .createHash("sha1")
     .update(branchName)

--- a/app/helpers/deployment-helpers.ts
+++ b/app/helpers/deployment-helpers.ts
@@ -30,7 +30,7 @@ const MAX_DOMAIN_LENGTH = 63;
 const BRANCH_HASH_LENGTH = 8;
 
 export function getBranchHandle(branchName: string) {
-  const handle = branchName.replace(/\//g, "-").replace(/_/g, "-").replace(/,/g, "-");
+  const handle = branchName.replace(/[\/_,]/g, "-");
   const hash = crypto
     .createHash("sha1")
     .update(branchName)

--- a/app/helpers/deployment-helpers.ts
+++ b/app/helpers/deployment-helpers.ts
@@ -30,7 +30,7 @@ const MAX_DOMAIN_LENGTH = 63;
 const BRANCH_HASH_LENGTH = 8;
 
 export function getBranchHandle(branchName: string) {
-  const handle = branchName.replace(/\//g, "-").replace(/_/g, "-");
+  const handle = branchName.replace(/\//g, "-").replace(/_/g, "-").replace(/,/g, "-");
   const hash = crypto
     .createHash("sha1")
     .update(branchName)


### PR DESCRIPTION
## Description

This extends the handler formatter to allow commas in branch names. 

### CR

I refactored the formatter to use a character set instead of chaining multiple `replace` methods.

Connects: https://github.com/iFixit/ifixit/issues/52365