### PR TITLE
Whitelist vercel deploy script

### DIFF
--- a/app/routes/github.webhook/pull-request-webhook.ts
+++ b/app/routes/github.webhook/pull-request-webhook.ts
@@ -13,12 +13,15 @@ export async function processPullRequestWebhook(
   repository: Repository
 ) {
   if (!repository.deployOnlyOnPullRequest)
-    return json({ message: "No action taken" });
+    return json({ message: "No action taken (deploy only on pull request)" });
 
   const [files, branch] = await findPullRequestData();
 
   if (!branch && !hasChangesAffectingNextjsApp())
-    return json({ message: "No action taken" });
+    return json({
+      message:
+        "No action taken (no branch or no changes found in `apps/`, `packages/` or `.github/workflows/nextjs-deploy-nextjs.yml`)",
+    });
 
   switch (webhook.payload.action) {
     case "opened":
@@ -31,7 +34,9 @@ export async function processPullRequestWebhook(
       return json({ message: `Deleting branch "${branchName()}"` });
     }
     default:
-      return json({ message: "No action taken" });
+      return json({
+        message: `No action taken for webhook payload action ${webhook.payload.action}`,
+      });
   }
 
   function findPullRequestData() {

--- a/app/routes/github.webhook/pull-request-webhook.ts
+++ b/app/routes/github.webhook/pull-request-webhook.ts
@@ -48,7 +48,8 @@ export async function processPullRequestWebhook(
     return files.some(
       (file) =>
         file.filename.startsWith("apps/") ||
-        file.filename.startsWith("packages/")
+        file.filename.startsWith("packages/") ||
+        file.filename === ".github/workflows/nextjs-deploy-nextjs.yml"
     );
   }
 


### PR DESCRIPTION
The ifixit-nextjs-dev PR deploy failed a few times in https://github.com/iFixit/ifixit/pull/55534, and it turns out we don't deploy strapi when there are changes to the vercel deploy script. This change deploys strapi in that case, and also clarifies the webhook response message to make debugging a little easier.

CC @jarstelfox