### PR TITLE
PR webhook: Only list filenames

### DIFF
--- a/app/routes/github.webhook/pull-request-webhook.ts
+++ b/app/routes/github.webhook/pull-request-webhook.ts
@@ -28,7 +28,7 @@ export async function processPullRequestWebhook(
       status: "skipped",
       message: "No action taken",
       reason: "There isn't a built branch and there aren't any changes affecting Nextjs",
-      filesChanged: files,
+      filesChanged: files.map((file) => file.filename),
       pullRequest: webhook.payload.number,
       repository: repository.id
     });


### PR DESCRIPTION
The output wasn't reasonable. It included the changed code and a bunch of other unnecessary stuff. Just list the filenames.

![image](https://github.com/user-attachments/assets/26926a7d-51d3-4785-9be5-df0eed4b0afa)


Ref: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files

qa_req 0

cc @dhmacs 