### PR TITLE
feat: sort branch previews by last updated

### DIFF
--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -1,15 +1,10 @@
 import dayjs from "dayjs";
 import { useHumanReadableDateTime } from "~/helpers/date-helpers";
-import type { BranchItem } from "~/models/branch.server";
+import type { LoaderData } from "~/routes/_index";
 import { BranchActions } from "~/routes/repositories.$id.branches._index";
 
-type SerializedBranch = Omit<BranchItem, "createdAt" | "updatedAt"> & {
-  createdAt: string;
-  updatedAt: string;
-};
-
 interface BranchPreviewsProps {
-  branches: SerializedBranch[];
+  branches: LoaderData["branches"];
   deployDomain: string;
 }
 

--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -49,7 +49,7 @@ export function BranchPreviews({
                   <circle cx={1} cy={1} r={1} />
                 </svg>
                 <p className="whitespace-nowrap">
-                  Last rebuilt{" "}
+                  Updated{" "}
                   {useHumanReadableDateTime(dayjs(branch.updatedAt))}
                 </p>
               </div>

--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -1,8 +1,15 @@
+import dayjs from "dayjs";
+import { useHumanReadableDateTime } from "~/helpers/date-helpers";
 import type { BranchItem } from "~/models/branch.server";
 import { BranchActions } from "~/routes/repositories.$id.branches._index";
 
+type SerializedBranch = Omit<BranchItem, "createdAt" | "lastRebuiltAt"> & {
+  createdAt: string;
+  lastRebuiltAt: string;
+};
+
 interface BranchPreviewsProps {
-  branches: BranchItem[];
+  branches: SerializedBranch[];
   deployDomain: string;
 }
 
@@ -35,6 +42,16 @@ export function BranchPreviews({
               </div>
               <div className="mt-3 flex items-center gap-x-2.5 text-xs leading-5 text-gray-400">
                 <p className="truncate">Deployed from {repositoryFullName}</p>
+                <svg
+                  viewBox="0 0 2 2"
+                  className="h-0.5 w-0.5 flex-none fill-gray-300"
+                >
+                  <circle cx={1} cy={1} r={1} />
+                </svg>
+                <p className="whitespace-nowrap">
+                  Last rebuilt{" "}
+                  {useHumanReadableDateTime(dayjs(branch.lastRebuiltAt))}
+                </p>
               </div>
             </div>
             <div className="flex flex-none items-center gap-x-4">

--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -3,9 +3,9 @@ import { useHumanReadableDateTime } from "~/helpers/date-helpers";
 import type { BranchItem } from "~/models/branch.server";
 import { BranchActions } from "~/routes/repositories.$id.branches._index";
 
-type SerializedBranch = Omit<BranchItem, "createdAt" | "lastRebuiltAt"> & {
+type SerializedBranch = Omit<BranchItem, "createdAt" | "updatedAt"> & {
   createdAt: string;
-  lastRebuiltAt: string;
+  updatedAt: string;
 };
 
 interface BranchPreviewsProps {
@@ -50,7 +50,7 @@ export function BranchPreviews({
                 </svg>
                 <p className="whitespace-nowrap">
                   Last rebuilt{" "}
-                  {useHumanReadableDateTime(dayjs(branch.lastRebuiltAt))}
+                  {useHumanReadableDateTime(dayjs(branch.updatedAt))}
                 </p>
               </div>
             </div>

--- a/app/components/sort-selector.tsx
+++ b/app/components/sort-selector.tsx
@@ -1,0 +1,56 @@
+import { Menu, Transition } from "@headlessui/react";
+import { ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import { Fragment } from "react";
+import { classNames } from "~/helpers/ui-helpers";
+import type { BranchSortField } from "~/models/branch.server";
+
+const SORT_OPTIONS: { value: BranchSortField; label: string }[] = [
+  { value: "name", label: "Name" },
+  { value: "lastRebuiltAt", label: "Last rebuilt" },
+];
+
+interface SortSelectorProps {
+  value: BranchSortField;
+  onChange: (value: string) => void;
+}
+
+export function SortSelector({ value, onChange }: SortSelectorProps) {
+  const activeOption =
+    SORT_OPTIONS.find((o) => o.value === value) ?? SORT_OPTIONS[0];
+  return (
+    <Menu as="div" className="relative">
+      <Menu.Button className="flex items-center gap-x-1 text-sm font-medium leading-6 text-gray-400 hover:text-white">
+        Sort: {activeOption.label}
+        <ChevronUpDownIcon className="h-5 w-5" aria-hidden="true" />
+      </Menu.Button>
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items className="absolute right-0 z-10 mt-2 w-40 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
+          {SORT_OPTIONS.map((option) => (
+            <Menu.Item key={option.value}>
+              {({ active }) => (
+                <button
+                  onClick={() => onChange(option.value)}
+                  className={classNames(
+                    active ? "bg-gray-100" : "",
+                    option.value === value ? "font-semibold" : "",
+                    "block w-full px-4 py-2 text-left text-sm text-gray-900"
+                  )}
+                >
+                  {option.label}
+                </button>
+              )}
+            </Menu.Item>
+          ))}
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+}

--- a/app/components/sort-selector.tsx
+++ b/app/components/sort-selector.tsx
@@ -15,7 +15,7 @@ export function SortSelector({ value, onChange }: SortSelectorProps) {
         className="col-start-1 row-start-1 w-full appearance-none rounded-md border-none bg-white/5 py-1.5 pr-8 pl-3 text-sm/6 text-white outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-500 *:bg-gray-800"
       >
         <option value="name">Sort by name</option>
-        <option value="lastRebuiltAt">Sort by last rebuilt</option>
+        <option value="updatedAt">Sort by last rebuilt</option>
       </select>
       <ChevronDownIcon
         aria-hidden="true"

--- a/app/components/sort-selector.tsx
+++ b/app/components/sort-selector.tsx
@@ -1,13 +1,5 @@
-import { Menu, Transition } from "@headlessui/react";
-import { ChevronUpDownIcon } from "@heroicons/react/20/solid";
-import { Fragment } from "react";
-import { classNames } from "~/helpers/ui-helpers";
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import type { BranchSortField } from "~/models/branch.server";
-
-const SORT_OPTIONS: { value: BranchSortField; label: string }[] = [
-  { value: "name", label: "Name" },
-  { value: "lastRebuiltAt", label: "Last rebuilt" },
-];
 
 interface SortSelectorProps {
   value: BranchSortField;
@@ -15,42 +7,20 @@ interface SortSelectorProps {
 }
 
 export function SortSelector({ value, onChange }: SortSelectorProps) {
-  const activeOption =
-    SORT_OPTIONS.find((o) => o.value === value) ?? SORT_OPTIONS[0];
   return (
-    <Menu as="div" className="relative">
-      <Menu.Button className="flex items-center gap-x-1 text-sm font-medium leading-6 text-gray-400 hover:text-white">
-        Sort: {activeOption.label}
-        <ChevronUpDownIcon className="h-5 w-5" aria-hidden="true" />
-      </Menu.Button>
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
+    <div className="grid grid-cols-1">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="col-start-1 row-start-1 w-full appearance-none rounded-md border-none bg-white/5 py-1.5 pr-8 pl-3 text-sm/6 text-white outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-500 *:bg-gray-800"
       >
-        <Menu.Items className="absolute right-0 z-10 mt-2 w-40 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
-          {SORT_OPTIONS.map((option) => (
-            <Menu.Item key={option.value}>
-              {({ active }) => (
-                <button
-                  onClick={() => onChange(option.value)}
-                  className={classNames(
-                    active ? "bg-gray-100" : "",
-                    option.value === value ? "font-semibold" : "",
-                    "block w-full px-4 py-2 text-left text-sm text-gray-900"
-                  )}
-                >
-                  {option.label}
-                </button>
-              )}
-            </Menu.Item>
-          ))}
-        </Menu.Items>
-      </Transition>
-    </Menu>
+        <option value="name">Sort by name</option>
+        <option value="lastRebuiltAt">Sort by last rebuilt</option>
+      </select>
+      <ChevronDownIcon
+        aria-hidden="true"
+        className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-400"
+      />
+    </div>
   );
 }

--- a/app/components/sort-selector.tsx
+++ b/app/components/sort-selector.tsx
@@ -15,7 +15,7 @@ export function SortSelector({ value, onChange }: SortSelectorProps) {
         className="col-start-1 row-start-1 w-full appearance-none rounded-md border-none bg-white/5 py-1.5 pr-8 pl-3 text-sm/6 text-white outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-500 *:bg-gray-800"
       >
         <option value="name">Sort by name</option>
-        <option value="updatedAt">Sort by last rebuilt</option>
+        <option value="updatedAt">Sort by last updated</option>
       </select>
       <ChevronDownIcon
         aria-hidden="true"

--- a/app/components/sort-selector.tsx
+++ b/app/components/sort-selector.tsx
@@ -1,26 +1,30 @@
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
+import { Form, useSubmit } from "@remix-run/react";
 import type { BranchSortField } from "~/models/branch.server";
 
 interface SortSelectorProps {
-  value: BranchSortField;
-  onChange: (value: string) => void;
+  defaultValue: BranchSortField;
 }
 
-export function SortSelector({ value, onChange }: SortSelectorProps) {
+export function SortSelector({ defaultValue }: SortSelectorProps) {
+  const submit = useSubmit();
+
   return (
-    <div className="grid grid-cols-1">
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="col-start-1 row-start-1 w-full appearance-none rounded-md border-none bg-white/5 py-1.5 pr-8 pl-3 text-sm/6 text-white outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-500 *:bg-gray-800"
-      >
-        <option value="name">Sort by name</option>
-        <option value="updatedAt">Sort by last updated</option>
-      </select>
-      <ChevronDownIcon
-        aria-hidden="true"
-        className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-400"
-      />
-    </div>
+    <Form method="get" onChange={(e) => submit(e.currentTarget)}>
+      <div className="grid grid-cols-1">
+        <select
+          name="sort"
+          defaultValue={defaultValue}
+          className="col-start-1 row-start-1 w-full appearance-none rounded-md border-none bg-white/5 py-1.5 pr-8 pl-3 text-sm/6 text-white outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-500 *:bg-gray-800"
+        >
+          <option value="name">Sort by name</option>
+          <option value="updatedAt">Sort by last updated</option>
+        </select>
+        <ChevronDownIcon
+          aria-hidden="true"
+          className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-400"
+        />
+      </div>
+    </Form>
   );
 }

--- a/app/jobs/push-job.server.ts
+++ b/app/jobs/push-job.server.ts
@@ -1,7 +1,7 @@
 import { Job } from "bullmq";
 import { BaseJob } from "~/lib/jobs.server";
 import { JobProgressLogger } from "~/lib/logger";
-import { findBranch } from "~/models/branch.server";
+import { findBranch, touchBranch } from "~/models/branch.server";
 import { deploy } from "~/models/commands/deploy.server";
 
 const queueName = "push";
@@ -18,6 +18,7 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
   protected async perform(job: Job<PushJobPayload>) {
     const branchName = job.data.branch;
     const logger = new JobProgressLogger(job);
+    await touchBranch(branchName);
     const branch = await findBranch(branchName);
     if (branch == null) {
       throw new Error(`Branch "${branchName}" not found`);

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -2,11 +2,18 @@ import { Prisma } from "@prisma/client";
 import { getBranchHandle } from "~/helpers/deployment-helpers";
 import { prisma } from "~/lib/db.server";
 
+export type BranchSortField = "name" | "lastRebuiltAt";
+
 export type BranchItem = NonNullable<
   Awaited<ReturnType<typeof findAllBranches>>
 >[number];
 
-export async function findAllBranches() {
+export async function findAllBranches(sort: BranchSortField = "name") {
+  const orderBy =
+    sort === "lastRebuiltAt"
+      ? { lastRebuiltAt: Prisma.SortOrder.desc }
+      : { name: Prisma.SortOrder.asc };
+
   return prisma.branch.findMany({
     take: 250,
     select: {
@@ -14,6 +21,8 @@ export async function findAllBranches() {
       handle: true,
       cloneUrl: true,
       dockerComposeDirectory: true,
+      createdAt: true,
+      lastRebuiltAt: true,
       repository: {
         select: {
           id: true,
@@ -21,9 +30,7 @@ export async function findAllBranches() {
         },
       },
     },
-    orderBy: {
-      name: Prisma.SortOrder.asc,
-    },
+    orderBy,
   });
 }
 
@@ -75,6 +82,7 @@ export async function upsertBranch(input: UpsertBranchInput) {
       cloneUrl: input.cloneUrl,
       dockerComposeDirectory: input.dockerComposeDirectory,
       repositoryId: input.repositoryId,
+      lastRebuiltAt: new Date(),
     },
     select: {
       name: true,
@@ -82,6 +90,13 @@ export async function upsertBranch(input: UpsertBranchInput) {
       cloneUrl: true,
       dockerComposeDirectory: true,
     },
+  });
+}
+
+export async function touchBranchLastRebuiltAt(branchName: string) {
+  return prisma.branch.update({
+    where: { name: branchName },
+    data: { lastRebuiltAt: new Date() },
   });
 }
 

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -8,7 +8,7 @@ export type BranchItem = NonNullable<
   Awaited<ReturnType<typeof findAllBranches>>
 >[number];
 
-export async function findAllBranches(sort: BranchSortField = "name") {
+export async function findAllBranches(sort: BranchSortField = "updatedAt") {
   const orderBy =
     sort === "updatedAt"
       ? { updatedAt: Prisma.SortOrder.desc }

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@prisma/client";
 import { getBranchHandle } from "~/helpers/deployment-helpers";
 import { prisma } from "~/lib/db.server";
 
-export type BranchSortField = "name" | "lastRebuiltAt";
+export type BranchSortField = "name" | "updatedAt";
 
 export type BranchItem = NonNullable<
   Awaited<ReturnType<typeof findAllBranches>>
@@ -10,8 +10,8 @@ export type BranchItem = NonNullable<
 
 export async function findAllBranches(sort: BranchSortField = "name") {
   const orderBy =
-    sort === "lastRebuiltAt"
-      ? { lastRebuiltAt: Prisma.SortOrder.desc }
+    sort === "updatedAt"
+      ? { updatedAt: Prisma.SortOrder.desc }
       : { name: Prisma.SortOrder.asc };
 
   return prisma.branch.findMany({
@@ -22,7 +22,7 @@ export async function findAllBranches(sort: BranchSortField = "name") {
       cloneUrl: true,
       dockerComposeDirectory: true,
       createdAt: true,
-      lastRebuiltAt: true,
+      updatedAt: true,
       repository: {
         select: {
           id: true,
@@ -82,7 +82,6 @@ export async function upsertBranch(input: UpsertBranchInput) {
       cloneUrl: input.cloneUrl,
       dockerComposeDirectory: input.dockerComposeDirectory,
       repositoryId: input.repositoryId,
-      lastRebuiltAt: new Date(),
     },
     select: {
       name: true,
@@ -93,10 +92,10 @@ export async function upsertBranch(input: UpsertBranchInput) {
   });
 }
 
-export async function touchBranchLastRebuiltAt(branchName: string) {
+export async function touchBranch(branchName: string) {
   return prisma.branch.update({
     where: { name: branchName },
-    data: { lastRebuiltAt: new Date() },
+    data: { updatedAt: new Date() },
   });
 }
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -19,7 +19,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   const sortParam = url.searchParams.get("sort");
   const sort: BranchSortField =
-    sortParam === "updatedAt" ? "updatedAt" : "name";
+    sortParam === "name" ? "name" : "updatedAt";
 
   const [systemStats, branches, deployments] = await Promise.all([
     getSystemStats(),

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,19 +1,29 @@
-import { Link, useLoaderData } from "@remix-run/react";
+import { LoaderFunctionArgs } from "@remix-run/node";
+import { Link, useLoaderData, useSearchParams } from "@remix-run/react";
 import { DEPLOY_DOMAIN } from "~/../config/env.server";
 import { BranchPreviews } from "~/components/branch-previews";
 import { DeploymentList } from "~/components/deployment-list";
+import { SortSelector } from "~/components/sort-selector";
 import { StatsSection } from "~/components/stats-section";
 import { BreadcrumbItem } from "~/lib/hooks/use-breadcrumbs";
-import { findAllBranches } from "~/models/branch.server";
+import {
+  findAllBranches,
+  type BranchSortField,
+} from "~/models/branch.server";
 import { findAllDeployments } from "~/models/deployment.server";
 import { getSystemStats } from "~/models/system.server";
 
 export type Loader = typeof loader;
 
-export const loader = async () => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const sortParam = url.searchParams.get("sort");
+  const sort: BranchSortField =
+    sortParam === "lastRebuiltAt" ? "lastRebuiltAt" : "name";
+
   const [systemStats, branches, deployments] = await Promise.all([
     getSystemStats(),
-    findAllBranches(),
+    findAllBranches(sort),
     findAllDeployments({ limit: 25 }),
   ]);
   return {
@@ -25,6 +35,7 @@ export const loader = async () => {
     branches,
     deployments,
     deployDomain: DEPLOY_DOMAIN,
+    sort,
   };
 };
 
@@ -40,8 +51,21 @@ export const handle = {
 };
 
 export default function Index() {
-  const { stats, branches, deployDomain, deployments } =
+  const { stats, branches, deployDomain, deployments, sort } =
     useLoaderData<Loader>();
+  const [, setSearchParams] = useSearchParams();
+
+  function handleSortChange(newSort: string) {
+    setSearchParams((prev) => {
+      if (newSort === "name") {
+        prev.delete("sort");
+      } else {
+        prev.set("sort", newSort);
+      }
+      return prev;
+    });
+  }
+
   return (
     <>
       <div className="relative">
@@ -51,6 +75,7 @@ export default function Index() {
             <h1 className="text-base font-semibold leading-7 text-white">
               Branch previews
             </h1>
+            <SortSelector value={sort} onChange={handleSortChange} />
           </header>
           <BranchPreviews branches={branches} deployDomain={deployDomain} />
         </main>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs } from "@remix-run/node";
-import { Link, useLoaderData, useSearchParams } from "@remix-run/react";
+import { Link, useLoaderData } from "@remix-run/react";
 import { DEPLOY_DOMAIN } from "~/../config/env.server";
 import { BranchPreviews } from "~/components/branch-previews";
 import { DeploymentList } from "~/components/deployment-list";
@@ -53,18 +53,6 @@ export const handle = {
 export default function Index() {
   const { stats, branches, deployDomain, deployments, sort } =
     useLoaderData<Loader>();
-  const [, setSearchParams] = useSearchParams();
-
-  function handleSortChange(newSort: string) {
-    setSearchParams((prev) => {
-      if (newSort === "updatedAt") {
-        prev.delete("sort");
-      } else {
-        prev.set("sort", newSort);
-      }
-      return prev;
-    });
-  }
 
   return (
     <>
@@ -75,7 +63,7 @@ export default function Index() {
             <h1 className="text-base font-semibold leading-7 text-white">
               Branch previews
             </h1>
-            <SortSelector value={sort} onChange={handleSortChange} />
+            <SortSelector defaultValue={sort} />
           </header>
           <BranchPreviews branches={branches} deployDomain={deployDomain} />
         </main>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { findAllDeployments } from "~/models/deployment.server";
 import { getSystemStats } from "~/models/system.server";
 
 export type Loader = typeof loader;
+export type LoaderData = ReturnType<typeof useLoaderData<Loader>>;
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -57,7 +57,7 @@ export default function Index() {
 
   function handleSortChange(newSort: string) {
     setSearchParams((prev) => {
-      if (newSort === "name") {
+      if (newSort === "updatedAt") {
         prev.delete("sort");
       } else {
         prev.set("sort", newSort);

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -19,7 +19,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   const sortParam = url.searchParams.get("sort");
   const sort: BranchSortField =
-    sortParam === "lastRebuiltAt" ? "lastRebuiltAt" : "name";
+    sortParam === "updatedAt" ? "updatedAt" : "name";
 
   const [systemStats, branches, deployments] = await Promise.all([
     getSystemStats(),

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -63,7 +63,7 @@ export default function Index() {
             <h1 className="text-base font-semibold leading-7 text-white">
               Branch previews
             </h1>
-            <SortSelector defaultValue={sort} />
+            <SortSelector key={sort} defaultValue={sort} />
           </header>
           <BranchPreviews branches={branches} deployDomain={deployDomain} />
         </main>

--- a/app/routes/repositories.$id.branches._index.tsx
+++ b/app/routes/repositories.$id.branches._index.tsx
@@ -15,10 +15,7 @@ import { DeleteDeploymentJob } from "~/jobs/delete-deployment-job.server";
 import { PushJob } from "~/jobs/push-job.server";
 import { flashMessage } from "~/lib/flash";
 import { commitSession, getSession } from "~/lib/session.server";
-import {
-  type BranchItem,
-  touchBranchLastRebuiltAt,
-} from "~/models/branch.server";
+import { type BranchItem, touchBranch } from "~/models/branch.server";
 
 enum Intent {
   Redeploy = "redeploy",
@@ -33,7 +30,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     case Intent.Redeploy: {
       const branchName = requireBranchName(formData);
       try {
-        await touchBranchLastRebuiltAt(branchName);
+        await touchBranch(branchName);
         await PushJob.performLater({
           branch: branchName,
         });

--- a/app/routes/repositories.$id.branches._index.tsx
+++ b/app/routes/repositories.$id.branches._index.tsx
@@ -15,7 +15,7 @@ import { DeleteDeploymentJob } from "~/jobs/delete-deployment-job.server";
 import { PushJob } from "~/jobs/push-job.server";
 import { flashMessage } from "~/lib/flash";
 import { commitSession, getSession } from "~/lib/session.server";
-import { type BranchItem, touchBranch } from "~/models/branch.server";
+import { type BranchItem } from "~/models/branch.server";
 
 enum Intent {
   Redeploy = "redeploy",
@@ -30,7 +30,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     case Intent.Redeploy: {
       const branchName = requireBranchName(formData);
       try {
-        await touchBranch(branchName);
         await PushJob.performLater({
           branch: branchName,
         });

--- a/app/routes/repositories.$id.branches._index.tsx
+++ b/app/routes/repositories.$id.branches._index.tsx
@@ -15,7 +15,10 @@ import { DeleteDeploymentJob } from "~/jobs/delete-deployment-job.server";
 import { PushJob } from "~/jobs/push-job.server";
 import { flashMessage } from "~/lib/flash";
 import { commitSession, getSession } from "~/lib/session.server";
-import type { BranchItem } from "~/models/branch.server";
+import {
+  type BranchItem,
+  touchBranchLastRebuiltAt,
+} from "~/models/branch.server";
 
 enum Intent {
   Redeploy = "redeploy",
@@ -30,6 +33,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     case Intent.Redeploy: {
       const branchName = requireBranchName(formData);
       try {
+        await touchBranchLastRebuiltAt(branchName);
         await PushJob.performLater({
           branch: branchName,
         });
@@ -106,7 +110,7 @@ function getErrorMessage(error: unknown): string {
 }
 
 interface BranchActionsProps {
-  branch: BranchItem;
+  branch: Pick<BranchItem, "name" | "repository">;
 }
 
 export function BranchActions({ branch }: BranchActionsProps) {

--- a/prisma/migrations/20260408093230_add_branch_timestamps/migration.sql
+++ b/prisma/migrations/20260408093230_add_branch_timestamps/migration.sql
@@ -7,10 +7,10 @@ CREATE TABLE "new_Branch" (
     "dockerComposeDirectory" TEXT NOT NULL,
     "repositoryId" TEXT,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "lastRebuiltAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "Branch_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository" ("id") ON DELETE SET NULL ON UPDATE CASCADE
 );
-INSERT INTO "new_Branch" ("cloneUrl", "dockerComposeDirectory", "handle", "name", "repositoryId") SELECT "cloneUrl", "dockerComposeDirectory", "handle", "name", "repositoryId" FROM "Branch";
+INSERT INTO "new_Branch" ("cloneUrl", "dockerComposeDirectory", "handle", "name", "repositoryId", "createdAt", "updatedAt") SELECT "cloneUrl", "dockerComposeDirectory", "handle", "name", "repositoryId", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM "Branch";
 DROP TABLE "Branch";
 ALTER TABLE "new_Branch" RENAME TO "Branch";
 CREATE UNIQUE INDEX "Branch_handle_key" ON "Branch"("handle");

--- a/prisma/migrations/20260408093230_add_branch_timestamps/migration.sql
+++ b/prisma/migrations/20260408093230_add_branch_timestamps/migration.sql
@@ -1,0 +1,18 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Branch" (
+    "name" TEXT NOT NULL PRIMARY KEY,
+    "handle" TEXT NOT NULL,
+    "cloneUrl" TEXT NOT NULL,
+    "dockerComposeDirectory" TEXT NOT NULL,
+    "repositoryId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastRebuiltAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Branch_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Branch" ("cloneUrl", "dockerComposeDirectory", "handle", "name", "repositoryId") SELECT "cloneUrl", "dockerComposeDirectory", "handle", "name", "repositoryId" FROM "Branch";
+DROP TABLE "Branch";
+ALTER TABLE "new_Branch" RENAME TO "Branch";
+CREATE UNIQUE INDEX "Branch_handle_key" ON "Branch"("handle");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,7 @@ model Branch {
   repository             Repository? @relation(fields: [repositoryId], references: [id])
   repositoryId           String?
   createdAt              DateTime    @default(now())
-  lastRebuiltAt          DateTime    @default(now())
+  updatedAt              DateTime    @updatedAt
 }
 
 model Repository {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,8 @@ model Branch {
   dockerComposeDirectory String
   repository             Repository? @relation(fields: [repositoryId], references: [id])
   repositoryId           String?
+  createdAt              DateTime    @default(now())
+  lastRebuiltAt          DateTime    @default(now())
 }
 
 model Repository {


### PR DESCRIPTION
closes #11

## Summary

Branch previews on the dashboard can now be sorted by last updated date (default) or by name. This makes it easier to find recently active branches, which is the most common use case when managing deployments.