### PR TITLE
feat: auto-recycle containers on low memory before deploy

### DIFF
--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
+import { StatusIndicator } from "~/components/status-indicator";
 import { useHumanReadableDateTime } from "~/helpers/date-helpers";
-import { classNames } from "~/helpers/ui-helpers";
 import type { LoaderData } from "~/routes/_index";
 import { BranchActions } from "~/routes/repositories.$id.branches._index";
 
@@ -25,25 +25,20 @@ export function BranchPreviews({
           >
             <div className="min-w-0 flex-auto">
               <div className="flex items-center gap-x-3">
-                <div
-                  className={classNames(
-                    "flex-none rounded-full p-1",
-                    branch.containerStatus === "running"
-                      ? "bg-green-400/10 text-green-400"
-                      : "bg-gray-400/10 text-gray-400"
-                  )}
-                >
-                  <div className="h-2 w-2 rounded-full bg-current" />
-                </div>
+                <StatusIndicator status={branch.containerStatus} />
                 <h2 className="min-w-0 text-sm font-semibold leading-6 text-white">
-                  <a
-                    href={`https://${branch.handle}.${deployDomain}/admin`}
-                    target="_blank"
-                    className="flex gap-x-2"
-                  >
+                  {branch.containerStatus === "running" ? (
+                    <a
+                      href={`https://${branch.handle}.${deployDomain}/admin`}
+                      target="_blank"
+                      className="flex gap-x-2"
+                    >
+                      <span className="whitespace-nowrap">{branch.name}</span>
+                      <span className="absolute inset-0" />
+                    </a>
+                  ) : (
                     <span className="whitespace-nowrap">{branch.name}</span>
-                    <span className="absolute inset-0" />
-                  </a>
+                  )}
                 </h2>
               </div>
               <div className="mt-3 flex items-center gap-x-2.5 text-xs leading-5 text-gray-400">

--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -18,6 +18,10 @@ export function BranchPreviews({
       {branches.map((branch) => {
         const repositoryFullName =
           branch.repository?.fullName ?? "react-commerce";
+        const isDeploying = branch.activity === "deploying";
+        const isReachable =
+          branch.containerStatus === "running" && !isDeploying;
+        const displayStatus = isDeploying ? "deploying" : branch.containerStatus;
         return (
           <li
             key={branch.handle}
@@ -25,9 +29,9 @@ export function BranchPreviews({
           >
             <div className="min-w-0 flex-auto">
               <div className="flex items-center gap-x-3">
-                <StatusIndicator status={branch.containerStatus} />
+                <StatusIndicator status={displayStatus} />
                 <h2 className="min-w-0 text-sm font-semibold leading-6 text-white">
-                  {branch.containerStatus === "running" ? (
+                  {isReachable ? (
                     <a
                       href={`https://${branch.handle}.${deployDomain}/admin`}
                       target="_blank"
@@ -56,7 +60,7 @@ export function BranchPreviews({
               </div>
             </div>
             <div className="flex flex-none items-center gap-x-4">
-              {branch.containerStatus === "running" ? (
+              {isReachable ? (
                 <a
                   href={`https://${branch.handle}.${deployDomain}/admin`}
                   target="_blank"
@@ -64,7 +68,7 @@ export function BranchPreviews({
                 >
                   Preview <span className="sr-only">, {branch.name}</span>
                 </a>
-              ) : branch.containerStatus === "deploying" ? (
+              ) : isDeploying ? (
                 <span className="hidden rounded-md bg-blue-500/10 px-2.5 py-1.5 text-sm font-semibold text-blue-400 animate-pulse sm:block">
                   Deploying…
                 </span>

--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -64,6 +64,10 @@ export function BranchPreviews({
                 >
                   Preview <span className="sr-only">, {branch.name}</span>
                 </a>
+              ) : branch.containerStatus === "deploying" ? (
+                <span className="hidden rounded-md bg-blue-500/10 px-2.5 py-1.5 text-sm font-semibold text-blue-400 animate-pulse sm:block">
+                  Deploying…
+                </span>
               ) : (
                 <span className="hidden rounded-md bg-gray-500/10 px-2.5 py-1.5 text-sm font-semibold text-gray-500 sm:block">
                   Stopped

--- a/app/components/branch-previews.tsx
+++ b/app/components/branch-previews.tsx
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import { useHumanReadableDateTime } from "~/helpers/date-helpers";
+import { classNames } from "~/helpers/ui-helpers";
 import type { LoaderData } from "~/routes/_index";
 import { BranchActions } from "~/routes/repositories.$id.branches._index";
 
@@ -24,6 +25,16 @@ export function BranchPreviews({
           >
             <div className="min-w-0 flex-auto">
               <div className="flex items-center gap-x-3">
+                <div
+                  className={classNames(
+                    "flex-none rounded-full p-1",
+                    branch.containerStatus === "running"
+                      ? "bg-green-400/10 text-green-400"
+                      : "bg-gray-400/10 text-gray-400"
+                  )}
+                >
+                  <div className="h-2 w-2 rounded-full bg-current" />
+                </div>
                 <h2 className="min-w-0 text-sm font-semibold leading-6 text-white">
                   <a
                     href={`https://${branch.handle}.${deployDomain}/admin`}
@@ -50,13 +61,19 @@ export function BranchPreviews({
               </div>
             </div>
             <div className="flex flex-none items-center gap-x-4">
-              <a
-                href={`https://${branch.handle}.${deployDomain}/admin`}
-                target="_blank"
-                className="hidden rounded-md bg-white/10 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-white/20 sm:block"
-              >
-                Preview <span className="sr-only">, {branch.name}</span>
-              </a>
+              {branch.containerStatus === "running" ? (
+                <a
+                  href={`https://${branch.handle}.${deployDomain}/admin`}
+                  target="_blank"
+                  className="hidden rounded-md bg-white/10 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-white/20 sm:block"
+                >
+                  Preview <span className="sr-only">, {branch.name}</span>
+                </a>
+              ) : (
+                <span className="hidden rounded-md bg-gray-500/10 px-2.5 py-1.5 text-sm font-semibold text-gray-500 sm:block">
+                  Stopped
+                </span>
+              )}
               <BranchActions branch={branch} />
             </div>
           </li>

--- a/app/components/status-indicator.tsx
+++ b/app/components/status-indicator.tsx
@@ -12,6 +12,7 @@ export function StatusIndicator({ className, status }: StatusIndicatorProps) {
         "flex-none rounded-full p-1",
         status === "completed" && "bg-green-400/10 text-green-400",
         status === "running" && "bg-green-400/10 text-green-400",
+        status === "deploying" && "bg-blue-400/10 text-blue-400 animate-pulse",
         status === "failed" && "bg-rose-400/10 text-rose-400",
         status === "delayed" && "bg-yellow-400/10 text-yellow-400",
         status === "active" && "bg-blue-400/10 text-blue-400",

--- a/app/components/status-indicator.tsx
+++ b/app/components/status-indicator.tsx
@@ -11,12 +11,14 @@ export function StatusIndicator({ className, status }: StatusIndicatorProps) {
       className={classNames(
         "flex-none rounded-full p-1",
         status === "completed" && "bg-green-400/10 text-green-400",
+        status === "running" && "bg-green-400/10 text-green-400",
         status === "failed" && "bg-rose-400/10 text-rose-400",
         status === "delayed" && "bg-yellow-400/10 text-yellow-400",
         status === "active" && "bg-blue-400/10 text-blue-400",
         status === "waiting" && "bg-orange-400/10 text-orange-400",
         status === "paused" && "bg-purple-400/10 text-purple-400",
         status === "repeat" && "bg-gray-100/10 text-gray-500",
+        status === "stopped" && "bg-gray-400/10 text-gray-400",
         className
       )}
     >

--- a/app/helpers/branch-helpers.ts
+++ b/app/helpers/branch-helpers.ts
@@ -1,4 +1,4 @@
-const PROTECTED_BRANCHES = ["main", "master"];
+export const PROTECTED_BRANCHES = ["main", "master"];
 
 export function isProtectedBranch(branchName: string): boolean {
   return PROTECTED_BRANCHES.includes(branchName);

--- a/app/jobs/push-job.server.ts
+++ b/app/jobs/push-job.server.ts
@@ -1,11 +1,7 @@
 import { Job } from "bullmq";
 import { BaseJob } from "~/lib/jobs.server";
 import { JobProgressLogger } from "~/lib/logger";
-import {
-  findBranch,
-  touchBranch,
-  updateBranchContainerStatus,
-} from "~/models/branch.server";
+import { findBranch, touchBranch } from "~/models/branch.server";
 import { deploy } from "~/models/commands/deploy.server";
 import { ensureMemoryAvailable } from "~/models/commands/ensure-memory.server";
 
@@ -36,7 +32,6 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
       branch,
       logger,
     });
-    await updateBranchContainerStatus(branchName, "running");
     return `Deployed branch "${branchName}"`;
   }
 

--- a/app/jobs/push-job.server.ts
+++ b/app/jobs/push-job.server.ts
@@ -1,7 +1,11 @@
 import { Job } from "bullmq";
 import { BaseJob } from "~/lib/jobs.server";
 import { JobProgressLogger } from "~/lib/logger";
-import { findBranch, touchBranch } from "~/models/branch.server";
+import {
+  findBranch,
+  touchBranch,
+  updateBranchContainerStatus,
+} from "~/models/branch.server";
 import { deploy } from "~/models/commands/deploy.server";
 import { ensureMemoryAvailable } from "~/models/commands/ensure-memory.server";
 
@@ -24,14 +28,24 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
     if (branch == null) {
       throw new Error(`Branch "${branchName}" not found`);
     }
-    await ensureMemoryAvailable({
-      logger,
-      excludeBranches: [branchName],
-    });
-    await deploy({
-      branch,
-      logger,
-    });
+    await updateBranchContainerStatus(branchName, "deploying");
+    try {
+      await ensureMemoryAvailable({
+        logger,
+        excludeBranches: [branchName],
+      });
+      await deploy({
+        branch,
+        logger,
+      });
+    } catch (error) {
+      // Any failure before deploy() marks the branch running leaves
+      // the row stuck in "deploying". Caddy-rollback failures are
+      // already flipped to "stopped" by stop(); this is the safety
+      // net for everything else (clone, compose up, memory checks).
+      await updateBranchContainerStatus(branchName, "stopped");
+      throw error;
+    }
     return `Deployed branch "${branchName}"`;
   }
 

--- a/app/jobs/push-job.server.ts
+++ b/app/jobs/push-job.server.ts
@@ -3,8 +3,8 @@ import { BaseJob } from "~/lib/jobs.server";
 import { JobProgressLogger } from "~/lib/logger";
 import {
   findBranch,
+  setBranchActivity,
   touchBranch,
-  updateBranchContainerStatus,
 } from "~/models/branch.server";
 import { deploy } from "~/models/commands/deploy.server";
 import { ensureMemoryAvailable } from "~/models/commands/ensure-memory.server";
@@ -28,7 +28,7 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
     if (branch == null) {
       throw new Error(`Branch "${branchName}" not found`);
     }
-    await updateBranchContainerStatus(branchName, "deploying");
+    await setBranchActivity(branchName, "deploying");
     try {
       await ensureMemoryAvailable({
         logger,
@@ -38,15 +38,14 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
         branch,
         logger,
       });
-    } catch (error) {
-      // Any failure before deploy() marks the branch running leaves
-      // the row stuck in "deploying". Caddy-rollback failures are
-      // already flipped to "stopped" by stop(); this is the safety
-      // net for everything else (clone, compose up, memory checks).
-      await updateBranchContainerStatus(branchName, "stopped");
-      throw error;
+      return `Deployed branch "${branchName}"`;
+    } finally {
+      // Clear activity regardless of outcome. containerStatus is
+      // owned by deploy()/stop() and already reflects reality — a
+      // failed redeploy of a live branch stays "running", a failed
+      // fresh deploy stays "stopped".
+      await setBranchActivity(branchName, "idle");
     }
-    return `Deployed branch "${branchName}"`;
   }
 
   protected getJobName(payload: PushJobPayload): string {

--- a/app/jobs/push-job.server.ts
+++ b/app/jobs/push-job.server.ts
@@ -1,8 +1,13 @@
 import { Job } from "bullmq";
 import { BaseJob } from "~/lib/jobs.server";
 import { JobProgressLogger } from "~/lib/logger";
-import { findBranch, touchBranch } from "~/models/branch.server";
+import {
+  findBranch,
+  touchBranch,
+  updateBranchContainerStatus,
+} from "~/models/branch.server";
 import { deploy } from "~/models/commands/deploy.server";
+import { ensureMemoryAvailable } from "~/models/commands/ensure-memory.server";
 
 const queueName = "push";
 
@@ -23,10 +28,15 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
     if (branch == null) {
       throw new Error(`Branch "${branchName}" not found`);
     }
+    await ensureMemoryAvailable({
+      logger,
+      excludeBranches: [branchName],
+    });
     await deploy({
       branch,
       logger,
     });
+    await updateBranchContainerStatus(branchName, "running");
     return `Deployed branch "${branchName}"`;
   }
 

--- a/app/jobs/push-job.server.ts
+++ b/app/jobs/push-job.server.ts
@@ -1,13 +1,8 @@
 import { Job } from "bullmq";
 import { BaseJob } from "~/lib/jobs.server";
 import { JobProgressLogger } from "~/lib/logger";
-import {
-  findBranch,
-  setBranchActivity,
-  touchBranch,
-} from "~/models/branch.server";
+import { findBranch, touchBranch } from "~/models/branch.server";
 import { deploy } from "~/models/commands/deploy.server";
-import { ensureMemoryAvailable } from "~/models/commands/ensure-memory.server";
 
 const queueName = "push";
 
@@ -28,24 +23,8 @@ export class PushJob extends BaseJob<PushJobPayload, PushJobResult> {
     if (branch == null) {
       throw new Error(`Branch "${branchName}" not found`);
     }
-    await setBranchActivity(branchName, "deploying");
-    try {
-      await ensureMemoryAvailable({
-        logger,
-        excludeBranches: [branchName],
-      });
-      await deploy({
-        branch,
-        logger,
-      });
-      return `Deployed branch "${branchName}"`;
-    } finally {
-      // Clear activity regardless of outcome. containerStatus is
-      // owned by deploy()/stop() and already reflects reality — a
-      // failed redeploy of a live branch stays "running", a failed
-      // fresh deploy stays "stopped".
-      await setBranchActivity(branchName, "idle");
-    }
+    await deploy({ branch, logger });
+    return `Deployed branch "${branchName}"`;
   }
 
   protected getJobName(payload: PushJobPayload): string {

--- a/app/lib/hooks/index.ts
+++ b/app/lib/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from "./use-stable-callback";
 export * from "./use-swr-data";

--- a/app/lib/hooks/use-stable-callback.ts
+++ b/app/lib/hooks/use-stable-callback.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Hook that returns a stable callback reference that always calls the latest version of the provided function.
+ * This is useful for event handlers and callbacks that need to be stable for performance reasons
+ * while still accessing the latest props and state.
+ *
+ * Approach inspired by Dan Abramov blog https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+ *
+ * React is planning to introduce something like this as a primitive in future versions
+ * https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event
+ *
+ * @param callback The callback function that may change between renders
+ * @returns A stable callback that always calls the latest version
+ *
+ * @example
+ * ```tsx
+ * function MyComponent({ onClick }) {
+ *   // onClick may change on every render, but stableOnClick remains the same
+ *   const stableOnClick = useStableCallback(onClick);
+ *
+ *   useEffect(() => {
+ *     // This effect only runs once because stableOnClick never changes
+ *     window.addEventListener('click', stableOnClick);
+ *     return () => window.removeEventListener('click', stableOnClick);
+ *   }, [stableOnClick]);
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useStableCallback<T extends ((...args: any[]) => any) | undefined>(callback: T): T {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stableCallback = useCallback((...args: any[]) => callbackRef.current?.(...args), []);
+
+  return (callback ? stableCallback : undefined) as T;
+}

--- a/app/lib/hooks/use-swr-data.ts
+++ b/app/lib/hooks/use-swr-data.ts
@@ -1,5 +1,6 @@
 import { useLoaderData, useRevalidator } from "@remix-run/react";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
+import { useStableCallback } from "./use-stable-callback";
 
 export interface UseSWRDataOptions {
   intervalMillis?: number;
@@ -10,45 +11,36 @@ export function useSWRData<Data = any>({
 }: UseSWRDataOptions = {}) {
   const loaderData = useLoaderData<Data>();
   const revalidator = useRevalidator();
-
-  const intervalId = useRef<number | null>(null);
+  const revalidate = useStableCallback(revalidator.revalidate);
 
   useEffect(() => {
-    const handleFocus = () => {
-      // If the window is focused and intervalId is not set (meaning the interval is not running),
-      // start the interval
-      if (intervalId.current == null) {
-        intervalId.current = window.setInterval(
-          revalidator.revalidate,
-          intervalMillis
-        );
+    let intervalId: number | null = null;
+
+    const start = () => {
+      if (intervalId == null) {
+        intervalId = window.setInterval(revalidate, intervalMillis);
       }
     };
 
-    const handleBlur = () => {
-      // If the window is blurred and intervalId is set (meaning the interval is running),
-      // clear the interval
-      if (intervalId.current != null) {
-        window.clearInterval(intervalId.current);
-        intervalId.current = null;
+    const stop = () => {
+      if (intervalId != null) {
+        window.clearInterval(intervalId);
+        intervalId = null;
       }
     };
 
-    // Add the focus and blur listeners when the component mounts
-    window.addEventListener("focus", handleFocus);
-    window.addEventListener("blur", handleBlur);
+    if (document.hasFocus()) {
+      start();
+    }
+    window.addEventListener("focus", start);
+    window.addEventListener("blur", stop);
 
-    // Clean up the focus and blur listeners when the component unmounts
     return () => {
-      window.removeEventListener("focus", handleFocus);
-      window.removeEventListener("blur", handleBlur);
-
-      // Also clear the interval when the component unmounts
-      if (intervalId.current != null) {
-        window.clearInterval(intervalId.current);
-        intervalId.current = null;
-      }
+      window.removeEventListener("focus", start);
+      window.removeEventListener("blur", stop);
+      stop();
     };
-  }, [revalidator.revalidate, intervalMillis]);
+  }, [revalidate, intervalMillis]);
+
   return loaderData;
 }

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -22,6 +22,7 @@ export async function findAllBranches(sort: BranchSortField = "updatedAt") {
       cloneUrl: true,
       dockerComposeDirectory: true,
       containerStatus: true,
+      activity: true,
       createdAt: true,
       updatedAt: true,
       repository: {
@@ -48,6 +49,7 @@ export async function findBranch(branchName: string) {
       cloneUrl: true,
       dockerComposeDirectory: true,
       containerStatus: true,
+      activity: true,
       repository: {
         select: {
           id: true,
@@ -109,7 +111,8 @@ export async function deleteBranch(branchName: string) {
   });
 }
 
-export type BranchContainerStatus = "running" | "stopped" | "deploying";
+export type BranchContainerStatus = "running" | "stopped";
+export type BranchActivity = "idle" | "deploying";
 
 export async function updateBranchContainerStatus(
   branchName: string,
@@ -124,10 +127,20 @@ export async function updateBranchContainerStatus(
   });
 }
 
-export async function resetDeployingBranchesToStopped() {
+export async function setBranchActivity(
+  branchName: string,
+  activity: BranchActivity
+) {
   return prisma.branch.updateMany({
-    where: { containerStatus: "deploying" },
-    data: { containerStatus: "stopped" },
+    where: { name: branchName },
+    data: { activity },
+  });
+}
+
+export async function resetAllBranchesToIdle() {
+  return prisma.branch.updateMany({
+    where: { activity: { not: "idle" } },
+    data: { activity: "idle" },
   });
 }
 
@@ -137,6 +150,9 @@ export async function findOldestRunningBranches(options?: {
   return prisma.branch.findMany({
     where: {
       containerStatus: "running",
+      // Never recycle a branch that has work in flight — a redeploy
+      // of a running branch should not be torn down mid-flight.
+      activity: "idle",
       ...(options?.exclude?.length
         ? { name: { notIn: options.exclude } }
         : {}),
@@ -147,6 +163,7 @@ export async function findOldestRunningBranches(options?: {
       cloneUrl: true,
       dockerComposeDirectory: true,
       containerStatus: true,
+      activity: true,
       repository: {
         select: {
           id: true,

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -113,7 +113,10 @@ export async function updateBranchContainerStatus(
   branchName: string,
   containerStatus: "running" | "stopped"
 ) {
-  return prisma.branch.update({
+  // updateMany is used here (instead of update) so the call silently
+  // no-ops if the row was deleted concurrently — e.g. a delete-deployment
+  // job racing with the post-stop status write in ensureMemoryAvailable.
+  return prisma.branch.updateMany({
     where: { name: branchName },
     data: { containerStatus },
   });

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -109,9 +109,11 @@ export async function deleteBranch(branchName: string) {
   });
 }
 
+export type BranchContainerStatus = "running" | "stopped" | "deploying";
+
 export async function updateBranchContainerStatus(
   branchName: string,
-  containerStatus: "running" | "stopped"
+  containerStatus: BranchContainerStatus
 ) {
   // updateMany is used here (instead of update) so the call silently
   // no-ops if the row was deleted concurrently — e.g. a delete-deployment
@@ -119,6 +121,13 @@ export async function updateBranchContainerStatus(
   return prisma.branch.updateMany({
     where: { name: branchName },
     data: { containerStatus },
+  });
+}
+
+export async function resetDeployingBranchesToStopped() {
+  return prisma.branch.updateMany({
+    where: { containerStatus: "deploying" },
+    data: { containerStatus: "stopped" },
   });
 }
 

--- a/app/models/branch.server.ts
+++ b/app/models/branch.server.ts
@@ -21,6 +21,7 @@ export async function findAllBranches(sort: BranchSortField = "updatedAt") {
       handle: true,
       cloneUrl: true,
       dockerComposeDirectory: true,
+      containerStatus: true,
       createdAt: true,
       updatedAt: true,
       repository: {
@@ -46,6 +47,7 @@ export async function findBranch(branchName: string) {
       handle: true,
       cloneUrl: true,
       dockerComposeDirectory: true,
+      containerStatus: true,
       repository: {
         select: {
           id: true,
@@ -104,5 +106,44 @@ export async function deleteBranch(branchName: string) {
     where: {
       name: branchName,
     },
+  });
+}
+
+export async function updateBranchContainerStatus(
+  branchName: string,
+  containerStatus: "running" | "stopped"
+) {
+  return prisma.branch.update({
+    where: { name: branchName },
+    data: { containerStatus },
+  });
+}
+
+export async function findOldestRunningBranches(options?: {
+  exclude?: string[];
+}) {
+  return prisma.branch.findMany({
+    where: {
+      containerStatus: "running",
+      ...(options?.exclude?.length
+        ? { name: { notIn: options.exclude } }
+        : {}),
+    },
+    select: {
+      name: true,
+      handle: true,
+      cloneUrl: true,
+      dockerComposeDirectory: true,
+      containerStatus: true,
+      repository: {
+        select: {
+          id: true,
+          name: true,
+          owner: true,
+          fullName: true,
+        },
+      },
+    },
+    orderBy: { updatedAt: "asc" },
   });
 }

--- a/app/models/commands/deploy.server.ts
+++ b/app/models/commands/deploy.server.ts
@@ -14,7 +14,7 @@ import { isPresent } from "~/helpers/application-helpers";
 import { getRepoDeployPath } from "~/helpers/deployment-helpers";
 import { Logger } from "~/lib/logger";
 import { Shell, SpawnCommand } from "~/lib/shell.server";
-import { Branch } from "../branch.server";
+import { Branch, updateBranchContainerStatus } from "../branch.server";
 import { cloneRepoCommand } from "./clone-repo";
 import { fetchLatestChangesCommand } from "./fetch-latest-changes";
 import { resetLocalBranchCommand } from "./reset-local-branch";
@@ -154,6 +154,7 @@ export async function deploy({ logger, branch }: DeployOptions): Promise<void> {
       rootDirectory: branch.dockerComposeDirectory,
     })
   );
+  await updateBranchContainerStatus(branch.name, "running");
   const hasDomainRoute = await hasDomainRouteForHandle(branch.handle);
   if (!hasDomainRoute) {
     await info("Assigning domain to deployment..");
@@ -269,6 +270,14 @@ export async function stop({ logger, branch }: StopOptions): Promise<void> {
         rootDirectory: branch.dockerComposeDirectory,
       })
     );
+    // Release the host port so it can't collide with another deployment
+    // that grabs it while this branch is stopped. The next deploy will
+    // allocate a fresh free port.
+    await removeEnvVariable({
+      name: "HOST_PORT",
+      branchHandle: branch.handle,
+      rootDirectory: branch.dockerComposeDirectory,
+    });
   }
 }
 
@@ -322,6 +331,38 @@ async function upsertEnvVariable({
 
   const env = result ? parse(result) : {};
   env[variable.name] = String(variable.value);
+  await fs.writeFile(envPath, stringify(env), "utf8");
+}
+
+interface RemoveEnvVariableOptions {
+  name: string;
+  branchHandle: string;
+  rootDirectory?: string;
+}
+
+async function removeEnvVariable({
+  name,
+  branchHandle,
+  rootDirectory,
+}: RemoveEnvVariableOptions): Promise<void> {
+  const workingDirectory = getRepoDeployPath({
+    rootDirectory,
+    branchHandle,
+  });
+  const envPath = `${workingDirectory}/.env`;
+
+  let result: string | undefined;
+  try {
+    result = await fs.readFile(envPath, "utf8");
+  } catch (error) {
+    return;
+  }
+
+  const env = parse(result);
+  if (!(name in env)) {
+    return;
+  }
+  delete env[name];
   await fs.writeFile(envPath, stringify(env), "utf8");
 }
 

--- a/app/models/commands/deploy.server.ts
+++ b/app/models/commands/deploy.server.ts
@@ -238,6 +238,40 @@ export async function destroy({
   }
 }
 
+interface StopOptions extends BaseOptions {
+  branch: Pick<Branch, "name" | "handle" | "dockerComposeDirectory">;
+}
+
+/**
+ * Stop a deployment's containers without destroying files or DB record.
+ * Lighter than destroy — allows fast restart on next deploy.
+ */
+export async function stop({ logger, branch }: StopOptions): Promise<void> {
+  if (process.env.NODE_ENV !== "production") {
+    await logger?.info(`[dev] Simulating stop for "${branch.name}"`);
+    return;
+  }
+  const info = createInfo(logger);
+  const shell = new Shell(logger);
+
+  const hasDomainRoute = await hasDomainRouteForHandle(branch.handle);
+  if (hasDomainRoute) {
+    await info("Removing domain route for stopped branch..");
+    await shell.run(removeCaddyRouteCommand({ branchHandle: branch.handle }));
+  }
+
+  const branchFolderExists = await hasBranchFolder(branch.handle);
+  if (branchFolderExists) {
+    await info(`Stopping containers for "${branch.name}"..`);
+    await shell.run(
+      dockerComposeStopCommand({
+        branchHandle: branch.handle,
+        rootDirectory: branch.dockerComposeDirectory,
+      })
+    );
+  }
+}
+
 async function doesDeploymentWithHandleExist(handle: string): Promise<boolean> {
   const handles = await getBranchFolderNames();
   return handles.includes(handle);
@@ -459,4 +493,20 @@ async function getBranchFolderName(branchHandle: string) {
 async function hasBranchFolder(branchHandle: string) {
   const name = await getBranchFolderName(branchHandle);
   return name != null;
+}
+
+function dockerComposeStopCommand({
+  branchHandle,
+  rootDirectory,
+}: DockerComposeDownCommandOptions): SpawnCommand {
+  const workingDirectory = getRepoDeployPath({
+    branchHandle,
+    rootDirectory,
+  });
+  return {
+    type: "spawn-command",
+    command: "docker",
+    args: ["compose", "-p", branchHandle, "stop"],
+    workingDirectory,
+  };
 }

--- a/app/models/commands/deploy.server.ts
+++ b/app/models/commands/deploy.server.ts
@@ -267,37 +267,41 @@ interface StopOptions extends BaseOptions {
  * Lighter than destroy — allows fast restart on next deploy.
  */
 export async function stop({ logger, branch }: StopOptions): Promise<void> {
-  if (process.env.NODE_ENV !== "production") {
-    await logger?.info(`[dev] Simulating stop for "${branch.name}"`);
-    return;
-  }
-  const info = createInfo(logger);
-  const shell = new Shell(logger);
+  if (process.env.NODE_ENV === "production") {
+    const info = createInfo(logger);
+    const shell = new Shell(logger);
 
-  const hasDomainRoute = await hasDomainRouteForHandle(branch.handle);
-  if (hasDomainRoute) {
-    await info("Removing domain route for stopped branch..");
-    await shell.run(removeCaddyRouteCommand({ branchHandle: branch.handle }));
-  }
+    const hasDomainRoute = await hasDomainRouteForHandle(branch.handle);
+    if (hasDomainRoute) {
+      await info("Removing domain route for stopped branch..");
+      await shell.run(removeCaddyRouteCommand({ branchHandle: branch.handle }));
+    }
 
-  const branchFolderExists = await hasBranchFolder(branch.handle);
-  if (branchFolderExists) {
-    await info(`Stopping containers for "${branch.name}"..`);
-    await shell.run(
-      dockerComposeStopCommand({
+    const branchFolderExists = await hasBranchFolder(branch.handle);
+    if (branchFolderExists) {
+      await info(`Stopping containers for "${branch.name}"..`);
+      await shell.run(
+        dockerComposeStopCommand({
+          branchHandle: branch.handle,
+          rootDirectory: branch.dockerComposeDirectory,
+        })
+      );
+      // Release the host port so it can't collide with another deployment
+      // that grabs it while this branch is stopped. The next deploy will
+      // allocate a fresh free port.
+      await removeEnvVariable({
+        name: "HOST_PORT",
         branchHandle: branch.handle,
         rootDirectory: branch.dockerComposeDirectory,
-      })
-    );
-    // Release the host port so it can't collide with another deployment
-    // that grabs it while this branch is stopped. The next deploy will
-    // allocate a fresh free port.
-    await removeEnvVariable({
-      name: "HOST_PORT",
-      branchHandle: branch.handle,
-      rootDirectory: branch.dockerComposeDirectory,
-    });
+      });
+    }
+  } else {
+    await logger?.info(`[dev] Simulating stop for "${branch.name}"`);
   }
+  // Own the DB transition so callers (deploy's rollback path,
+  // ensureMemoryAvailable) can't leave the row out of sync with the
+  // side effects we just performed.
+  await updateBranchContainerStatus(branch.name, "stopped");
 }
 
 async function doesDeploymentWithHandleExist(handle: string): Promise<boolean> {

--- a/app/models/commands/deploy.server.ts
+++ b/app/models/commands/deploy.server.ts
@@ -154,18 +154,37 @@ export async function deploy({ logger, branch }: DeployOptions): Promise<void> {
       rootDirectory: branch.dockerComposeDirectory,
     })
   );
-  await updateBranchContainerStatus(branch.name, "running");
-  const hasDomainRoute = await hasDomainRouteForHandle(branch.handle);
-  if (!hasDomainRoute) {
-    await info("Assigning domain to deployment..");
-    await shell.run(
-      addCaddyRouteCommand({
-        port,
-        branchHandle: branch.handle,
-        rootDirectory: branch.dockerComposeDirectory,
-      })
-    );
+  // Only mark running once the preview route is in place, so the
+  // dashboard invariant holds: containerStatus === "running" ⟺ the
+  // preview is actually reachable. If route assignment fails we tear
+  // the containers back down so we don't leak memory on a branch the
+  // UI can no longer show.
+  try {
+    const hasDomainRoute = await hasDomainRouteForHandle(branch.handle);
+    if (!hasDomainRoute) {
+      await info("Assigning domain to deployment..");
+      await shell.run(
+        addCaddyRouteCommand({
+          port,
+          branchHandle: branch.handle,
+          rootDirectory: branch.dockerComposeDirectory,
+        })
+      );
+    }
+  } catch (error) {
+    await info("Route assignment failed, rolling back containers..");
+    try {
+      await stop({ logger, branch });
+    } catch (rollbackError) {
+      await info(
+        rollbackError instanceof Error
+          ? `Rollback failed: ${rollbackError.message}`
+          : "Rollback failed with unknown error"
+      );
+    }
+    throw error;
   }
+  await updateBranchContainerStatus(branch.name, "running");
 }
 
 function createInfo(

--- a/app/models/commands/deploy.server.ts
+++ b/app/models/commands/deploy.server.ts
@@ -14,8 +14,13 @@ import { isPresent } from "~/helpers/application-helpers";
 import { getRepoDeployPath } from "~/helpers/deployment-helpers";
 import { Logger } from "~/lib/logger";
 import { Shell, SpawnCommand } from "~/lib/shell.server";
-import { Branch, updateBranchContainerStatus } from "../branch.server";
+import {
+  Branch,
+  setBranchActivity,
+  updateBranchContainerStatus,
+} from "../branch.server";
 import { cloneRepoCommand } from "./clone-repo";
+import { ensureMemoryAvailable } from "./ensure-memory.server";
 import { fetchLatestChangesCommand } from "./fetch-latest-changes";
 import { resetLocalBranchCommand } from "./reset-local-branch";
 
@@ -37,10 +42,27 @@ interface DeployOptions extends BaseOptions {
  * @param options Options for the deployment.
  */
 export async function deploy({ logger, branch }: DeployOptions): Promise<void> {
-  if (process.env.NODE_ENV !== "production") {
-    await logger?.info(`[dev] Simulating deploy for "${branch.name}"`);
-    return;
+  await setBranchActivity(branch.name, "deploying");
+  try {
+    await ensureMemoryAvailable({
+      logger,
+      excludeBranches: [branch.name],
+    });
+    if (process.env.NODE_ENV !== "production") {
+      await simulateDeploy({ logger, branch });
+    } else {
+      await runDeploy({ logger, branch });
+    }
+  } finally {
+    // Clear activity regardless of outcome. containerStatus is
+    // owned by runDeploy()/stop() and already reflects reality — a
+    // failed redeploy of a live branch stays "running", a failed
+    // fresh deploy stays "stopped".
+    await setBranchActivity(branch.name, "idle");
   }
+}
+
+async function runDeploy({ logger, branch }: DeployOptions): Promise<void> {
   invariant(branch.repository, "Branch must have a repository to deploy.");
   const info = createInfo(logger);
   const shell = new Shell(logger);
@@ -185,6 +207,24 @@ export async function deploy({ logger, branch }: DeployOptions): Promise<void> {
     throw error;
   }
   await updateBranchContainerStatus(branch.name, "running");
+}
+
+async function simulateDeploy({
+  logger,
+  branch,
+}: DeployOptions): Promise<void> {
+  const info = createInfo(logger);
+  await info(`[dev] Simulating deploy for "${branch.name}"..`);
+  await info("[dev] Simulating build..");
+  await sleep(2000);
+  await info("[dev] Simulating container start..");
+  await sleep(1000);
+  await info("[dev] Deploy complete");
+  await updateBranchContainerStatus(branch.name, "running");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function createInfo(
@@ -332,7 +372,7 @@ async function getDeploymentPort(
       return undefined;
     }
     return port;
-  } catch (error) {}
+  } catch (error) { }
   return undefined;
 }
 
@@ -350,7 +390,7 @@ async function upsertEnvVariable({
   let result: string | undefined;
   try {
     result = await fs.readFile(envPath, "utf8");
-  } catch (error) {}
+  } catch (error) { }
 
   const env = result ? parse(result) : {};
   env[variable.name] = String(variable.value);

--- a/app/models/commands/ensure-memory.server.ts
+++ b/app/models/commands/ensure-memory.server.ts
@@ -1,0 +1,61 @@
+import { DEPLOY_MEMORY_THRESHOLD_BYTES } from "~/../config/env.server";
+import { Logger } from "~/lib/logger";
+import {
+  findOldestRunningBranches,
+  updateBranchContainerStatus,
+} from "~/models/branch.server";
+import { getAvailableMemoryBytes } from "~/models/system.server";
+import { stop } from "./deploy.server";
+
+interface EnsureMemoryOptions {
+  logger?: Logger;
+  excludeBranches?: string[];
+}
+
+export async function ensureMemoryAvailable({
+  logger,
+  excludeBranches = [],
+}: EnsureMemoryOptions): Promise<void> {
+  let availableMemory = await getAvailableMemoryBytes();
+
+  if (availableMemory >= DEPLOY_MEMORY_THRESHOLD_BYTES) {
+    await logger?.info(
+      `Memory OK: ${formatMB(availableMemory)} available, threshold is ${formatMB(DEPLOY_MEMORY_THRESHOLD_BYTES)}`
+    );
+    return;
+  }
+
+  await logger?.info(
+    `Low memory: ${formatMB(availableMemory)} available, need ${formatMB(DEPLOY_MEMORY_THRESHOLD_BYTES)}. Starting recycling..`
+  );
+
+  const candidates = await findOldestRunningBranches({
+    exclude: excludeBranches,
+  });
+
+  for (const candidate of candidates) {
+    if (availableMemory >= DEPLOY_MEMORY_THRESHOLD_BYTES) {
+      break;
+    }
+
+    await logger?.info(`Stopping branch "${candidate.name}" to free memory..`);
+    await stop({ logger, branch: candidate });
+    await updateBranchContainerStatus(candidate.name, "stopped");
+
+    availableMemory = await getAvailableMemoryBytes();
+    await logger?.info(
+      `After stopping "${candidate.name}": ${formatMB(availableMemory)} available`
+    );
+  }
+
+  if (availableMemory < DEPLOY_MEMORY_THRESHOLD_BYTES) {
+    throw new Error(
+      `Insufficient memory: ${formatMB(availableMemory)} available after stopping all eligible branches. ` +
+        `Required: ${formatMB(DEPLOY_MEMORY_THRESHOLD_BYTES)}.`
+    );
+  }
+}
+
+function formatMB(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))}MB`;
+}

--- a/app/models/commands/ensure-memory.server.ts
+++ b/app/models/commands/ensure-memory.server.ts
@@ -17,6 +17,10 @@ export async function ensureMemoryAvailable({
   logger,
   excludeBranches = [],
 }: EnsureMemoryOptions): Promise<void> {
+  if (process.env.NODE_ENV !== "production") {
+    await logger?.info("[dev] Skipping memory check");
+    return;
+  }
   let availableMemory = await getAvailableMemoryBytes();
 
   if (availableMemory >= DEPLOY_MEMORY_THRESHOLD_BYTES) {

--- a/app/models/commands/ensure-memory.server.ts
+++ b/app/models/commands/ensure-memory.server.ts
@@ -1,10 +1,7 @@
 import { DEPLOY_MEMORY_THRESHOLD_BYTES } from "~/../config/env.server";
 import { PROTECTED_BRANCHES } from "~/helpers/branch-helpers";
 import { Logger } from "~/lib/logger";
-import {
-  findOldestRunningBranches,
-  updateBranchContainerStatus,
-} from "~/models/branch.server";
+import { findOldestRunningBranches } from "~/models/branch.server";
 import { getAvailableMemoryBytes } from "~/models/system.server";
 import { stop } from "./deploy.server";
 
@@ -45,7 +42,6 @@ export async function ensureMemoryAvailable({
 
     await logger?.info(`Stopping branch "${candidate.name}" to free memory..`);
     await stop({ logger, branch: candidate });
-    await updateBranchContainerStatus(candidate.name, "stopped");
 
     availableMemory = await getAvailableMemoryBytes();
     await logger?.info(

--- a/app/models/commands/ensure-memory.server.ts
+++ b/app/models/commands/ensure-memory.server.ts
@@ -1,4 +1,5 @@
 import { DEPLOY_MEMORY_THRESHOLD_BYTES } from "~/../config/env.server";
+import { PROTECTED_BRANCHES } from "~/helpers/branch-helpers";
 import { Logger } from "~/lib/logger";
 import {
   findOldestRunningBranches,
@@ -30,7 +31,7 @@ export async function ensureMemoryAvailable({
   );
 
   const candidates = await findOldestRunningBranches({
-    exclude: excludeBranches,
+    exclude: [...excludeBranches, ...PROTECTED_BRANCHES],
   });
 
   for (const candidate of candidates) {

--- a/app/models/system.server.ts
+++ b/app/models/system.server.ts
@@ -38,3 +38,19 @@ async function getAvailableMemory(): Promise<string> {
   }
   return result.output;
 }
+
+export async function getAvailableMemoryBytes(): Promise<number> {
+  const shell = new Shell();
+  const result = await shell.run({
+    type: "command",
+    command: "free -b | awk '/Mem:/ {print $7}'",
+  });
+  if (result == null) {
+    throw new Error("Failed to get available memory");
+  }
+  const bytes = parseInt(result.output.trim(), 10);
+  if (!Number.isFinite(bytes)) {
+    throw new Error(`Failed to parse available memory: "${result.output}"`);
+  }
+  return bytes;
+}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,6 +5,7 @@ import { BranchPreviews } from "~/components/branch-previews";
 import { DeploymentList } from "~/components/deployment-list";
 import { SortSelector } from "~/components/sort-selector";
 import { StatsSection } from "~/components/stats-section";
+import { useSWRData } from "~/lib/hooks";
 import { BreadcrumbItem } from "~/lib/hooks/use-breadcrumbs";
 import {
   findAllBranches,
@@ -53,7 +54,7 @@ export const handle = {
 
 export default function Index() {
   const { stats, branches, deployDomain, deployments, sort } =
-    useLoaderData<Loader>();
+    useSWRData<Loader>();
 
   return (
     <>

--- a/config/env.server.ts
+++ b/config/env.server.ts
@@ -27,3 +27,10 @@ export const STRAPI_ADMIN_BACKEND_URL =
 export const GITHUB_API_TOKEN = process.env.GITHUB_API_TOKEN;
 
 export const DEEPL_API_KEY = process.env.DEEPL_API_KEY;
+
+const DEFAULT_MEMORY_THRESHOLD_MB = 1536;
+export const DEPLOY_MEMORY_THRESHOLD_BYTES =
+  (parseInt(process.env.DEPLOY_MEMORY_THRESHOLD_MB ?? "", 10) ||
+    DEFAULT_MEMORY_THRESHOLD_MB) *
+  1024 *
+  1024;

--- a/prisma/migrations/20260409125759_add_container_status/migration.sql
+++ b/prisma/migrations/20260409125759_add_container_status/migration.sql
@@ -1,0 +1,19 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Branch" (
+    "name" TEXT NOT NULL PRIMARY KEY,
+    "handle" TEXT NOT NULL,
+    "cloneUrl" TEXT NOT NULL,
+    "dockerComposeDirectory" TEXT NOT NULL,
+    "containerStatus" TEXT NOT NULL DEFAULT 'running',
+    "repositoryId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Branch_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Branch" ("cloneUrl", "createdAt", "dockerComposeDirectory", "handle", "name", "repositoryId", "updatedAt") SELECT "cloneUrl", "createdAt", "dockerComposeDirectory", "handle", "name", "repositoryId", "updatedAt" FROM "Branch";
+DROP TABLE "Branch";
+ALTER TABLE "new_Branch" RENAME TO "Branch";
+CREATE UNIQUE INDEX "Branch_handle_key" ON "Branch"("handle");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20260410143221_change_branch_status_default_to_stopped/migration.sql
+++ b/prisma/migrations/20260410143221_change_branch_status_default_to_stopped/migration.sql
@@ -1,0 +1,19 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Branch" (
+    "name" TEXT NOT NULL PRIMARY KEY,
+    "handle" TEXT NOT NULL,
+    "cloneUrl" TEXT NOT NULL,
+    "dockerComposeDirectory" TEXT NOT NULL,
+    "containerStatus" TEXT NOT NULL DEFAULT 'stopped',
+    "repositoryId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Branch_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Branch" ("cloneUrl", "containerStatus", "createdAt", "dockerComposeDirectory", "handle", "name", "repositoryId", "updatedAt") SELECT "cloneUrl", "containerStatus", "createdAt", "dockerComposeDirectory", "handle", "name", "repositoryId", "updatedAt" FROM "Branch";
+DROP TABLE "Branch";
+ALTER TABLE "new_Branch" RENAME TO "Branch";
+CREATE UNIQUE INDEX "Branch_handle_key" ON "Branch"("handle");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20260414133422_add_branch_activity/migration.sql
+++ b/prisma/migrations/20260414133422_add_branch_activity/migration.sql
@@ -1,0 +1,20 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Branch" (
+    "name" TEXT NOT NULL PRIMARY KEY,
+    "handle" TEXT NOT NULL,
+    "cloneUrl" TEXT NOT NULL,
+    "dockerComposeDirectory" TEXT NOT NULL,
+    "containerStatus" TEXT NOT NULL DEFAULT 'stopped',
+    "activity" TEXT NOT NULL DEFAULT 'idle',
+    "repositoryId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Branch_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Branch" ("cloneUrl", "containerStatus", "createdAt", "dockerComposeDirectory", "handle", "name", "repositoryId", "updatedAt") SELECT "cloneUrl", "containerStatus", "createdAt", "dockerComposeDirectory", "handle", "name", "repositoryId", "updatedAt" FROM "Branch";
+DROP TABLE "Branch";
+ALTER TABLE "new_Branch" RENAME TO "Branch";
+CREATE UNIQUE INDEX "Branch_handle_key" ON "Branch"("handle");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Branch {
   handle                 String      @unique
   cloneUrl               String
   dockerComposeDirectory String
+  containerStatus        String      @default("running")
   repository             Repository? @relation(fields: [repositoryId], references: [id])
   repositoryId           String?
   createdAt              DateTime    @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Branch {
   handle                 String      @unique
   cloneUrl               String
   dockerComposeDirectory String
-  containerStatus        String      @default("running")
+  containerStatus        String      @default("stopped")
   repository             Repository? @relation(fields: [repositoryId], references: [id])
   repositoryId           String?
   createdAt              DateTime    @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model Branch {
   cloneUrl               String
   dockerComposeDirectory String
   containerStatus        String      @default("stopped")
+  activity               String      @default("idle")
   repository             Repository? @relation(fields: [repositoryId], references: [id])
   repositoryId           String?
   createdAt              DateTime    @default(now())

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -1,5 +1,5 @@
 import { DeleteDeploymentJob } from "~/jobs/delete-deployment-job.server";
-import { resetDeployingBranchesToStopped } from "~/models/branch.server";
+import { resetAllBranchesToIdle } from "~/models/branch.server";
 import { PushJob } from "../app/jobs/push-job.server";
 import { connection } from "../config/jobs";
 
@@ -8,13 +8,14 @@ let deleteDeploymentJob: DeleteDeploymentJob;
 
 checkRedisConnection().then(async () => {
   console.log("redis is ready");
-  // Any branch left in "deploying" at worker startup belongs to a
-  // previous worker run that crashed mid-deploy. Reset them so the
-  // UI doesn't show a forever-pulsating indicator and the recycler
-  // can reclaim their containers if memory gets tight.
-  const { count } = await resetDeployingBranchesToStopped();
+  // Any non-idle activity at worker startup belongs to a previous
+  // worker run that crashed mid-job. Clear it so the UI doesn't
+  // show a forever-pulsating indicator. containerStatus is left
+  // alone — a branch that was actually running before the crash
+  // stays "running", so the recycler and dashboard still see it.
+  const { count } = await resetAllBranchesToIdle();
   if (count > 0) {
-    console.log(`reset ${count} orphaned deploying branch(es) to stopped`);
+    console.log(`reset ${count} orphaned branch activity row(s) to idle`);
   }
   pushJob = new PushJob();
   pushJob.startWorker({ connection });

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -1,12 +1,21 @@
 import { DeleteDeploymentJob } from "~/jobs/delete-deployment-job.server";
+import { resetDeployingBranchesToStopped } from "~/models/branch.server";
 import { PushJob } from "../app/jobs/push-job.server";
 import { connection } from "../config/jobs";
 
 let pushJob: PushJob;
 let deleteDeploymentJob: DeleteDeploymentJob;
 
-checkRedisConnection().then(() => {
+checkRedisConnection().then(async () => {
   console.log("redis is ready");
+  // Any branch left in "deploying" at worker startup belongs to a
+  // previous worker run that crashed mid-deploy. Reset them so the
+  // UI doesn't show a forever-pulsating indicator and the recycler
+  // can reclaim their containers if memory gets tight.
+  const { count } = await resetDeployingBranchesToStopped();
+  if (count > 0) {
+    console.log(`reset ${count} orphaned deploying branch(es) to stopped`);
+  }
   pushJob = new PushJob();
   pushJob.startWorker({ connection });
   deleteDeploymentJob = new DeleteDeploymentJob();


### PR DESCRIPTION
## Summary

Deploying branches accumulates running Docker containers, which can exhaust server memory and cause deployments to fail. This adds a pre-deploy memory check that automatically stops the oldest idle containers to make room for new deployments.

Key points:
- Configurable memory threshold via `DEPLOY_MEMORY_THRESHOLD_MB` env var (default 1.5GB)
- Stopped branches keep their files and DB record — they restart automatically on next push or manual redeploy
- Uses `docker compose stop` (not `down`) for fast restarts
- UI now shows green/gray status dot per branch and replaces the Preview button with "Stopped" label for inactive containers

## QA

- [ ] Deploy a branch, verify it shows a green status dot and `containerStatus` is `"running"` in DB
- [ ] Set `DEPLOY_MEMORY_THRESHOLD_MB` to a very high value, deploy a new branch, verify the oldest running branch gets stopped and shows a gray dot with "Stopped" label
- [ ] Redeploy a stopped branch, verify it transitions back to running with green dot and working Preview link
- [ ] Verify `npm run typecheck` passes