### PR TITLE
feat: warn before removing protected branches from the UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ npm run deploy           # Build + migrate + restart systemd service
 
 Remix 2.6, React 18, TypeScript (strict), Prisma 4 (SQLite), BullMQ (Redis), Tailwind CSS 3 (JIT), Headless UI, Octokit, Zod, dayjs
 
+## Pull Requests
+
+PRs are squash-merged, so the PR title becomes the commit on `main`. Use conventional commits syntax (`feat:`, `fix:`, `refactor:`, `chore:`, etc., with optional scope) for PR titles.
+
 ## Dev Environment
 
 - Node.js v20+ (see `.nvmrc` for exact version)

--- a/app/helpers/branch-helpers.ts
+++ b/app/helpers/branch-helpers.ts
@@ -1,0 +1,5 @@
+const PROTECTED_BRANCHES = ["main", "master"];
+
+export function isProtectedBranch(branchName: string): boolean {
+  return PROTECTED_BRANCHES.includes(branchName);
+}

--- a/app/routes/repositories.$id.branches._index.tsx
+++ b/app/routes/repositories.$id.branches._index.tsx
@@ -8,6 +8,7 @@ import { ActionFunctionArgs, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";
 import { Fragment } from "react";
 import invariant from "tiny-invariant";
+import { isProtectedBranch } from "~/helpers/branch-helpers";
 import { MessageType } from "~/components/global-notification";
 import { branchesPath } from "~/helpers/path-helpers";
 import { classNames } from "~/helpers/ui-helpers";
@@ -163,6 +164,16 @@ export function BranchActions({ branch }: BranchActionsProps) {
                 action={branchesPath(repository)}
                 method="POST"
                 reloadDocument
+                onSubmit={(e) => {
+                  if (
+                    isProtectedBranch(branch.name) &&
+                    !window.confirm(
+                      `"${branch.name}" is used to seed data for other deployments. Are you sure you want to remove it?`
+                    )
+                  ) {
+                    e.preventDefault();
+                  }
+                }}
                 className={classNames(
                   active ? "bg-red-100" : "",
                   "text-sm leading-6 text-red-600 cursor-pointer"


### PR DESCRIPTION
## Summary

The main/master branch deployment is used by other deploys and local dev to seed Strapi data. Adds a confirmation dialog when attempting to remove these branches from the dashboard to prevent accidental removal.

Scoped narrowly to the UI only — webhook-triggered deletion and auto-recycle flows are not addressed here.