### PR TITLE
fix(ui): make the "Deploy branch" action a prominent button

### DIFF
--- a/app/routes/repositories.$id._index.tsx
+++ b/app/routes/repositories.$id._index.tsx
@@ -1,7 +1,7 @@
 import {
   CheckIcon,
   ClipboardIcon,
-  PlusSmallIcon,
+  RocketLaunchIcon,
 } from "@heroicons/react/20/solid";
 import {
   ActionFunction,
@@ -98,23 +98,25 @@ export default function RepositoryPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-8">
-      <header className="py-8 flex justify-between">
+      <header className="py-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-2xl font-bold leading-7 text-white sm:truncate sm:text-3xl sm:tracking-tight">
             {repository.fullName}
           </h2>
-          <div className="text-gray-500 font-mono text-sm mt-2 flex items-center space-x-4">
+          <div className="text-gray-500 font-mono text-sm mt-2">
             <span>{branchCount} deployed branches</span>
-            <Link
-              to={newBranchPath(repository)}
-              className="font-bold inline-flex"
-            >
-              <PlusSmallIcon className="h-5 w-5" aria-hidden="true" />
-              <span>Deploy branch</span>
-            </Link>
           </div>
         </div>
-        <div></div>
+        <Link
+          to={newBranchPath(repository)}
+          className="group inline-flex flex-shrink-0 items-center gap-x-2 self-start rounded-md bg-indigo-500 px-4 py-2.5 text-sm font-semibold text-white shadow-sm shadow-indigo-500/30 transition-all hover:bg-indigo-400 hover:shadow-md hover:shadow-indigo-400/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 sm:self-auto"
+        >
+          <RocketLaunchIcon
+            className="h-5 w-5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+          Deploy branch
+        </Link>
       </header>
 
       <main className="">


### PR DESCRIPTION
## Problem

On the repository page, the **Deploy branch** action was styled as faint bold text with a small `+` icon, tucked inline inside the gray `font-mono` metadata row next to "X deployed branches". It didn't read as a button at all.

This caused real UX friction — in [this Slack thread](https://inkofpixel.slack.com/archives/C90126AN4/p1781625492628729), multiple devs reported overlooking it entirely and assuming there was no way to manually trigger a deploy:

> "That deploy branch button does not look like a button so I overlooked it"
> "I agree it does not look like a button, I had to ask in Slack to discover it a while back."
> "I ran into this same issue the other day and did not know that was a button as well."

## Fix

Promote it to a real, unmissable primary button and move it to the conventional top-right action slot of the header (the spot already reserved by an empty `<div>`):

- Solid indigo primary styling, matching the existing **Deploy** submit button on the new-branch page — so the design language stays consistent.
- A `RocketLaunchIcon` to reinforce the "deploy" action, with a subtle lift-off micro-interaction on hover.
- Soft indigo glow shadow that intensifies on hover for prominence on the dark background.
- Accessible `focus-visible` outline.
- Responsive: stacks below the title on mobile, sits right-aligned on `sm+`.

The metadata row now just shows the branch count, removing the confusingly-styled inline link.

## Notes

- Scoped to the button UX only. The thread also surfaced a separate issue (branch names with slashes failing because the name is used in the URL hostname) — that warrants its own PR for input sanitization and isn't addressed here.
- `npm run typecheck` passes.