### PR TITLE
Normalize branch handle to a guaranteed-valid DNS label

### DIFF
--- a/app/helpers/deployment-helpers.ts
+++ b/app/helpers/deployment-helpers.ts
@@ -1,48 +1,55 @@
-import crypto from "crypto";
-import { DEPLOYMENTS_DIRECTORY } from "~/../config/env.server";
+import crypto from 'crypto';
+import { DEPLOYMENTS_DIRECTORY } from '~/../config/env.server';
 
 interface GetRepoDeployPathOptions {
-  branchHandle: string;
-  rootDirectory?: string;
+   branchHandle: string;
+   rootDirectory?: string;
 }
 
 export function getRepoDeployPath(options: GetRepoDeployPathOptions) {
-  const repoPath = getRepoPath(options.branchHandle);
-  const deployPath = options.rootDirectory
-    ? getRelativePath(options.rootDirectory)
-    : "";
-  let cwd = repoPath;
-  if (deployPath.length > 0) {
-    cwd += `/${deployPath}`;
-  }
-  return cwd;
+   const repoPath = getRepoPath(options.branchHandle);
+   const deployPath = options.rootDirectory ? getRelativePath(options.rootDirectory) : '';
+   let cwd = repoPath;
+   if (deployPath.length > 0) {
+      cwd += `/${deployPath}`;
+   }
+   return cwd;
 }
 
 export function getRepoPath(branchHandle: string) {
-  return `${DEPLOYMENTS_DIRECTORY}/${branchHandle}`;
+   return `${DEPLOYMENTS_DIRECTORY}/${branchHandle}`;
 }
 
 function getRelativePath(path: string) {
-  return path.replace(/\/$/g, "").replace(/^\//g, "");
+   return path.replace(/\/$/g, '').replace(/^\//g, '');
 }
 
 const MAX_DOMAIN_LENGTH = 63;
 const BRANCH_HASH_LENGTH = 8;
 
+// The handle becomes the branch's preview subdomain, i.e. a single DNS label.
+// It must be lowercase, contain only [a-z0-9-], have no leading/trailing dash,
+// and no "--" (which collides with the reserved xn-- punycode prefix and makes
+// ACME refuse to issue a cert). Normalize to a guaranteed-valid label rather
+// than assuming the branch name is already clean.
 export function getBranchHandle(branchName: string) {
-  const handle = branchName.replace(/[^a-zA-Z0-9]/g, "-");
-  const hash = crypto
-    .createHash("sha1")
-    .update(branchName)
-    .digest("hex")
-    .substring(0, BRANCH_HASH_LENGTH);
+   const handle = branchName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-') // collapse runs of invalid chars to one dash
+      .replace(/^-+|-+$/g, ''); // trim leading/trailing dashes
 
-  if (handle.length <= MAX_DOMAIN_LENGTH) {
-    return handle;
-  }
-  const truncatedHandle = handle.substring(
-    0,
-    MAX_DOMAIN_LENGTH - BRANCH_HASH_LENGTH
-  );
-  return `${truncatedHandle}${hash}`;
+   // Hash the raw branch name so distinct branches never collide on a handle.
+   const hash = crypto
+      .createHash('sha1')
+      .update(branchName)
+      .digest('hex')
+      .substring(0, BRANCH_HASH_LENGTH);
+
+   if (handle.length <= MAX_DOMAIN_LENGTH) {
+      return handle;
+   }
+   const truncatedHandle = handle
+      .substring(0, MAX_DOMAIN_LENGTH - BRANCH_HASH_LENGTH - 1)
+      .replace(/-+$/g, ''); // don't leave a trailing dash before the hash join
+   return `${truncatedHandle}-${hash}`;
 }


### PR DESCRIPTION
## Summary

`getBranchHandle` builds the subdomain for a branch's Strapi preview (`${branch.handle}.${DEPLOY_DOMAIN}`), so the handle has to be a legal single DNS label. The old one-liner assumed the branch name was already clean:

```ts
const handle = branchName.replace(/[^a-zA-Z0-9]/g, "-");
```

That maps a lone `/` to `-` fine, but emits **invalid DNS labels** in three cases:

- **`--` survives or is created.** A dash is itself the replacement char with no run-collapsing, so `my--branch` stays `my--branch` and any two adjacent specials (`foo//bar`) become `--`. A `--` in positions 3–4 collides with the reserved `xn--` punycode prefix (RFC 5891), so ACME refuses to issue a cert and the preview never comes up.
- **Leading/trailing hyphens**, which DNS labels forbid (RFC 952/1123): `-wip`, `feature/` → `feature-`.
- **Uppercase passthrough**, leaving the `@id` / on-disk folder mixed-case while docker lowercases the compose project name underneath — an identity mismatch that can strand a route or folder on destroy.

This normalizes to a guaranteed-valid label instead of assuming clean input: lowercase, collapse runs of invalid chars to a single dash (kills `--`), trim leading/trailing dashes, and in the truncation path trim a trailing dash before joining the hash so it can't produce `...--<hash>`. The hash still digests the **raw** branch name so distinct branches never collide.

This is the authoritative chokepoint every branch flows through, regardless of origin. It complements the pre-push hook in [iFixit/ifixit#62618](https://github.com/iFixit/ifixit/pull/62618), which only catches branches pushed from a local checkout — branches created on GitHub directly, other repos pointed at Govinor, or anything bypassing the hook still slip through here.

## QA

Ran the new normalization over the recommended cases. Every result is a valid label (lowercase, `[a-z0-9-]`, no leading/trailing dash, no `--`, ≤63 chars):

| input | handle |
|-------|--------|
| `feat/foo` | `feat-foo` |
| `my--branch` | `my-branch` |
| `-wip` | `wip` |
| `feature/` | `feature` |
| `Foo/Bar` | `foo-bar` |
| `foo//bar` | `foo-bar` |
| `release/.x` | `release-x` |
| `good-branch` | `good-branch` |
| 80-char name + `/x` | truncated to 63, ends `-73e55a53` |

> [!NOTE]
> **Migration caveat.** This changes the handle for any branch whose current handle differs (those with `--`, end dashes, or uppercase). The handle is the identity for the Caddy `@id`, the docker-compose project, and the on-disk folder. In practice the risk is small: [`upsertBranch`](https://github.com/iFixit/govinor/blob/master/app/models/branch.server.ts#L72-L89) writes `handle` only in the `create` block, not `update`, so an already-deployed branch keeps its stored handle on redeploy — only a fully re-created branch row would pick up the new handle and could orphan the old route/folder/container. Those are rare (and mostly the already-broken ones). Redeploy or manually clean any in-flight branch that changes handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)